### PR TITLE
Fix entry point reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # DiscordRoleBot
+
+Install the dependencies listed in `requirements.txt` and start the bot using
+`python bot.py`. The `bot.py` script is the main entry point for the
+application.


### PR DESCRIPTION
## Summary
- update README to mention `bot.py` as the script to run

## Testing
- `python3 -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6853f861505c83329c68fc389ace039c